### PR TITLE
emit $chart-update AFTER chart is actually updated

### DIFF
--- a/src/components/Chart.svelte
+++ b/src/components/Chart.svelte
@@ -133,13 +133,14 @@ function quantizeCursor() {
 
 function update(emit = true) {
     // Emit a global event (hook)
+    if (emit) events.emit('$chart-pre-update')
     //Utils.callsPerSecond()
     if (scan.panesChanged()) return fullUpdate()
     cursor = cursor // Trigger Svelte update
     layout = new Layout(chartProps, hub, meta)
     events.emit('update-pane', layout) // Update all panes
     events.emitSpec('botbar', 'update-bb', layout)
-    if (emit) events.emit('$chart-update')
+    if (emit) events.emit('$chart-post-update')
 }
 
 // Full update when the dataset changed completely

--- a/src/components/Chart.svelte
+++ b/src/components/Chart.svelte
@@ -133,13 +133,13 @@ function quantizeCursor() {
 
 function update(emit = true) {
     // Emit a global event (hook)
-    if (emit) events.emit('$chart-update')
     //Utils.callsPerSecond()
     if (scan.panesChanged()) return fullUpdate()
     cursor = cursor // Trigger Svelte update
     layout = new Layout(chartProps, hub, meta)
     events.emit('update-pane', layout) // Update all panes
     events.emitSpec('botbar', 'update-bb', layout)
+    if (emit) events.emit('$chart-update')
 }
 
 // Full update when the dataset changed completely


### PR DESCRIPTION
Update hook should be emitted AFTER chart is updated. This is much move convenient to be notified only ONCE all chart updates have been done.