### PR TITLE
Lazy import hammer and hamster which access `window`

### DIFF
--- a/src/components/Sidebar.svelte
+++ b/src/components/Sidebar.svelte
@@ -16,7 +16,6 @@
 import { onMount, onDestroy } from 'svelte'
 import { fade } from 'svelte/transition'
 import ScaleSelector from './ScaleSelector.svelte'
-import Hammer from 'hammerjs'
 import Events from '../core/events.js'
 import Utils from '../stuff/utils.js'
 import math from '../stuff/math.js'
@@ -68,22 +67,23 @@ $:width = layout.width
 $:height = layout.height
 $:resizeWatch(width, height)
 
-onMount(() => { setup() })
+onMount(async () => { await setup() })
 onDestroy(() => {
     events.off(`${sbUpdId}`)
     if (mc) mc.destroy()
 })
 
-function setup() {
+async function setup() {
     [canvas, ctx] = dpr.setup(
         canvasId, layout.sbMax[S], layout.height)
 
     update()
-    if (scale) listeners()
+    if (scale) await listeners()
 }
 
 // TODO: add mouse wheel/touchpad zoom
-function listeners() {
+async function listeners() {
+    const Hammer = await import('hammerjs');
     mc = new Hammer.Manager(canvas)
         mc.add(new Hammer.Pan({
             direction: Hammer.DIRECTION_VERTICAL,

--- a/src/core/input/pointer.js
+++ b/src/core/input/pointer.js
@@ -6,8 +6,6 @@
 // Output: internal events
 
 import FrameAnimation from '../../stuff/frame.js'
-import Hammer from 'hammerjs'
-import Hamster from 'hamsterjs'
 import Utils from '../../stuff/utils.js'
 import math from '../../stuff/math.js'
 import Events from '../events.js'
@@ -16,7 +14,7 @@ import MetaHub from '../metaHub.js'
 
 export default class Input {
 
-    setup(comp) {
+    async setup(comp) {
 
         this.MIN_ZOOM = comp.props.config.MIN_ZOOM
         this.MAX_ZOOM = comp.props.config.MAX_ZOOM
@@ -43,7 +41,7 @@ export default class Input {
         this.meta = MetaHub.instance(this.props.id)
         this.events = Events.instance(this.props.id)
 
-        this.listeners()
+        await this.listeners()
         this.mouseEvents('addEventListener')
     }
 
@@ -58,7 +56,10 @@ export default class Input {
         })
     }
 
-    listeners() {
+    async listeners() {
+        const Hamster = await import('hamsterjs');
+        const Hammer = await import('hammerjs');
+
         this.hm = Hamster(this.canvas)
         this.hm.wheel((event, delta) => this.mousezoom(-delta * 50, event))
 

--- a/src/core/input/pointer.js
+++ b/src/core/input/pointer.js
@@ -60,7 +60,7 @@ export default class Input {
         const Hamster = await import('hamsterjs');
         const Hammer = await import('hammerjs');
 
-        this.hm = Hamster(this.canvas)
+        this.hm = Hamster.default(this.canvas)
         this.hm.wheel((event, delta) => this.mousezoom(-delta * 50, event))
 
         let mc = this.mc = new Hammer.Manager(this.canvas)


### PR DESCRIPTION
Resolves browser access errors on server when SSR isn't enabled on that page for sveltekit projects.

Was getting, simply importing NightVision modules as previously simply importing like `import { NightVision } from 'night-vision';` at the top of the project would try to access browser based functions
```
window is not defined
ReferenceError: window is not defined
    at /node_modules/night-vision/dist/night-vision.js:5092:6
    at /node_modules/night-vision/dist/night-vision.js:5093:3
```

Chart would still need to be initialized `onMount`.