### PR TITLE
fix display of candle remaining time

### DIFF
--- a/src/core/primitives/sidebar.js
+++ b/src/core/primitives/sidebar.js
@@ -106,17 +106,33 @@ function tracker(props, layout, scale, side, ctx, tracker) {
     let x = S ? 1 : 4
     let y = tracker.y - panHeight * 0.5 + HPX
     let a = S ? 7 : panWidth - 3
-    let h = ct ? Math.floor(panHeight * 1.75) + 2 + HPX : panHeight
+
+    let h = panHeight
+    let rt
+
+    if (ct) {
+      // if candle time is set we compute the remaining time
+      // and grow the height of the rectangle
+      const data = props.cursor.meta.hub.mainOv.data
+      const lastOpen = data[data.length - 1][0]
+      const nextClose = lastOpen + props.timeFrame + 1000
+
+      rt = Utils.getCandleTime(nextClose)
+
+      if (rt) {
+        h = Math.floor(panHeight * 1.75) + 2 + HPX
+      }
+    }
+
     roundRect(ctx, x , y, panWidth, h, 3, S)
     ctx.fillStyle = props.colors.back
     ctx.textAlign = S ? 'left' : 'right'
     ctx.fillText(lbl, a, y + panHeight - 4) // TODO: remove hardcode
-    if (ct) {
-        let rt = Utils.getCandleTime(props.timeFrame)
-        ctx.textAlign = S ? 'left' : 'right'
-        ctx.fillText(rt, a, y + panHeight + 9) // TODO: remove hardcode
-    }
 
+    if (rt) {
+      ctx.textAlign = S ? 'left' : 'right'
+      ctx.fillText(rt, a, y + panHeight + 9) // TODO: remove hardcode
+    }
 }
 
 function roundRect(ctx, x, y, w, h, r, s) {

--- a/src/stuff/constants.js
+++ b/src/stuff/constants.js
@@ -6,9 +6,14 @@ const MINUTE5 = MINUTE * 5
 const MINUTE15 = MINUTE * 15
 const MINUTE30 = MINUTE * 30
 const HOUR = MINUTE * 60
+const HOUR2 = HOUR * 2
+const HOUR3 = HOUR * 3
 const HOUR4 = HOUR * 4
+const HOUR6 = HOUR * 6
+const HOUR8 = HOUR * 8
 const HOUR12 = HOUR * 12
 const DAY = HOUR * 24
+const DAY3 = DAY * 3
 const WEEK = DAY * 7
 const MONTH = WEEK * 4
 const YEAR = DAY * 365
@@ -112,6 +117,8 @@ const MAP_UNIT = {
   "2H": HOUR * 2,
   "3H": HOUR * 3,
   "4H": HOUR4,
+  "6H": HOUR6,
+  "8H": HOUR8,
   "12H": HOUR12,
   "1D": DAY,
   "1W": WEEK,
@@ -122,6 +129,8 @@ const MAP_UNIT = {
   "2h": HOUR * 2,
   "3h": HOUR * 3,
   "4h": HOUR4,
+  "6h": HOUR6,
+  "8h": HOUR8,
   "12h": HOUR12,
   "1d": DAY,
   "1w": WEEK,

--- a/src/stuff/utils.js
+++ b/src/stuff/utils.js
@@ -2,11 +2,6 @@
 import IndexedArray from 'arrayslicer'
 import Const from './constants.js'
 
-const {
-    MINUTE, MINUTE5, MINUTE15, HOUR, HOUR4,
-    DAY, WEEK, MONTH, YEAR
-} = Const
-
 export default {
 
     clamp(num, min, max) {
@@ -531,62 +526,42 @@ export default {
         return $cursor
     },
 
-    // GPT to the moon!
-    getCandleTime(tf) {
-        const now = new Date(),
-            h = now.getUTCHours(),
-            m = now.getUTCMinutes(),
-            s = now.getUTCSeconds(),
-            Mo = now.getUTCMonth(),
-            D = now.getUTCDay(),
-            Y = now.getUTCFullYear();
+    // returns formatted remaining candle time until next close (unix ms ts)
+    getCandleTime(nextClose) {
+      const now = new Date();
+      const utcTs = now.getTime()
+      const ms = nextClose - utcTs
 
-        let rt; 
+      const seconds = Math.floor(ms / 1000);
+      const minutes = Math.floor(seconds / 60);
+      const hours = Math.floor(minutes / 60);
+      const days = Math.floor(hours / 24);
 
-        switch (tf) {
-            case MINUTE:
-                rt = 60 - s;
-                return `00:${rt < 10 ? '0' : ''}${rt}`;
-            case MINUTE5:
-                rt = 5 * 60 - (m % 5) * 60 - s;
-                return `${Math.floor(rt / 60)}:${rt % 60 < 10 ? '0' : ''}${rt % 60}`;
-            case MINUTE15:
-                rt = 15 * 60 - (m % 15) * 60 - s;
-                return `${Math.floor(rt / 60)}:${rt % 60 < 10 ? '0' : ''}${rt % 60}`;
-            case HOUR:
-                rt = 60 * 60 - m * 60 - s;
-                return `${(Math.floor(rt % 3600 / 60) + '').padStart(2, '0')}:` +
-                    `${(rt % 60 + '').padStart(2, '0')}`;
-            case HOUR4:
-                rt = 4 * 60 * 60 - (h % 4) * 3600 - m * 60 - s;
-                const hours = Math.floor(rt / 3600);
-                const minutes = Math.floor(rt % 3600 / 60);
-                if (hours === 0) {
-                    return `${minutes}:${(rt % 60 + '').padStart(2, '0')}`;
-                } else {
-                    return `${hours}:${(minutes + '').padStart(2, '0')}:${(rt % 60 + '').padStart(2, '0')}`;
-                }
-            case DAY:
-                rt = 24 * 60 * 60 - h * 3600 - m * 60 - s;
-                return `${Math.floor(rt / 3600)}:` +
-                    `${(Math.floor(rt % 3600 / 60) + '').padStart(2, '0')}:` +
-                    `${(rt % 60 + '').padStart(2, '0')}`;
-            case WEEK:
-                rt = 7 * 24 * 60 * 60 - (D || 7) * 24 * 60 * 60 - h * 3600 - m * 60 - s;
-                return `${Math.floor(rt / (24 * 3600))}d ${Math.floor(rt % (24 * 3600) / 3600)}h`;
-            case MONTH:
-                const endOfMonth = new Date(Date.UTC(now.getUTCFullYear(), Mo + 1, 1));
-                rt = (endOfMonth - now) / 1000;
-                return `${Math.floor(rt / (24 * 3600))}d ${Math.floor(rt % (24 * 3600) / 3600)}h`;
-            case YEAR:
-                const startOfYear = new Date(Date.UTC(Y, 0, 1));
-                const endOfYear = new Date(Date.UTC(Y + 1, 0, 1));
-                const totalSecondsInYear = (endOfYear - startOfYear) / 1000;
-                rt = totalSecondsInYear - ((now - startOfYear) / 1000);
-                return `${Math.floor(rt / (24 * 3600))}d ${Math.floor(rt % (24 * 3600) / 3600)}h`;
-            default:
-                return "Unk TF";
-        }
+      const formattedDays = days > 0 ? `${days}d` : '';
+      if (formattedDays) {
+        const hours = Math.ceil(minutes / 60);
+        const formattedHours = hours % 24 > 0 ? `${(hours % 24).toString().padStart(2, '0')}` : '';
+        return `${formattedDays} ${formattedHours}h`
+      }
+
+      const formattedHours = hours % 24 > 0 ? `${(hours % 24).toString().padStart(2, '0')}` : '';
+      const formattedMinutes = minutes % 60 > 0 ? `${(minutes % 60).toString().padStart(2, '0')}` : '';
+      const formattedSeconds = seconds % 60 > 0 ? `${(seconds % 60).toString().padStart(2, '0')}` : '';
+
+      if (formattedHours && formattedMinutes && formattedSeconds) {
+        return `${formattedHours}:${formattedMinutes}:${formattedSeconds}`
+      }
+
+      if (formattedMinutes && formattedSeconds) {
+        return `${formattedMinutes}:${formattedSeconds}`
+      }
+
+      if (formattedSeconds) {
+        return `00:${formattedSeconds}`
+      }
+
+      // this is when chart might not be updated, ie nextClose is lt utcTs
+      return ''
     },
 
     // WTF with modern web development


### PR DESCRIPTION
candle remaining time is kinda broken, see 1w timeframe for an example .. i propose computing the remaining time based on the last close time from the data set and the current timestamp .. if the dataset is not up to date, no remaining time will be shown even if it's set to true in the settings

it also adds some extra timeframes in the mix