### PR TITLE
feat: add support for updateBotbar (see line 203 in Chart.svelte)

### DIFF
--- a/src/components/Botbar.svelte
+++ b/src/components/Botbar.svelte
@@ -1,10 +1,10 @@
 <script>
-// The Bottom Bar. Information flow:
-// Input: props, layout, (?events)
-// Output: canvas, (?events)
+  // The Bottom Bar. Information flow:
+  // Input: props, layout, (?events)
+  // Output: canvas, (?events)
 
-// TODO: add support of overlays with
-// drawBotbar() function
+  // TODO: add support of overlays with
+  // drawBotbar() function
 
 import { onMount, onDestroy } from 'svelte'
 import Events from '../core/events.js'
@@ -12,17 +12,19 @@ import Utils from '../stuff/utils.js'
 import dpr from '../stuff/dprCanvas.js'
 import bb from '../core/primitives/botbar.js'
 
-export let props = {} // General props
-export let layout = {} // Grid layout
+  export let props = {} // General props
+  export let layout = {} // Grid layout
 
-let bbUpdId = `botbar`
-let bbId = `${props.id}-botbar`
-let canvasId = `${props.id}-botbar-canvas`
+  export let grids = []
+  $: layers = grids.map((grid) => grid.getLayers() || []).flat()
+  let bbUpdId = `botbar`
+  let bbId = `${props.id}-botbar`
+  let canvasId = `${props.id}-botbar-canvas`
 
-let events = Events.instance(props.id)
+  let events = Events.instance(props.id)
 
-// EVENT INTERFACE
-events.on(`${bbUpdId}:update-bb`, update)
+  // EVENT INTERFACE
+  events.on(`${bbUpdId}:update-bb`, update)
 events.on(`${bbUpdId}:show-bb-panel`, f => showPanel = f)
 
 $:bbStyle = `
@@ -31,27 +33,27 @@ $:bbStyle = `
     height: ${(layout.botbar || {}).height}px;
 `
 
-let canvas // Canvas ref
-let ctx // Canvas context
-let showPanel = true
+  let canvas // Canvas ref
+  let ctx // Canvas context
+  let showPanel = true
 
 $:width = (layout.botbar || {}).width
 $:resizeWatch(width)
 
 onMount(() => { setup() })
-onDestroy(() => {
+  onDestroy(() => {
     events.off(`${bbUpdId}`)
-})
+  })
 
-function setup() {
+  function setup() {
     let botbar = layout.botbar;
     [canvas, ctx] = dpr.setup(
         canvasId, botbar.width, botbar.height)
 
     update()
-}
+  }
 
-function update($layout = layout) {
+  function update($layout = layout) {
     layout = $layout
 
     if (!layout.botbar) return // If not exists
@@ -59,20 +61,32 @@ function update($layout = layout) {
     bb.body(props, layout, ctx)
 
     // applyShaders()
+    ovDrawCalls($layout)
 
     if (props.cursor.x && props.cursor.ti !== undefined && showPanel) {
-        bb.panel(props, layout, ctx)
+      bb.panel(props, layout, ctx)
     }
-}
+  }
 
-function resizeWatch() {
+  function resizeWatch() {
     let botbar = layout.botbar
     if (!canvas || !botbar) return
     dpr.resize(canvas, ctx, botbar.width, botbar.height)
     update()
-}
+  }
 
-/*function applyShaders() {
+  // Draw stuff from overlay scripts
+  function ovDrawCalls($layout) {
+    if (layout.botbar) {
+      for (var l of layers) {
+        let ov = l.overlay
+        if (ov.drawBotbar) ov.drawBotbar(ctx)
+      }
+    }
+    // TODO: implementation
+  }
+
+  /*function applyShaders() {
     let props = {
         layout: layout,
         cursor: props.cursor
@@ -89,5 +103,5 @@ function resizeWatch() {
 .nvjs-botbar {}
 </style>
 <div class="nvjs-botbar" id={bbId} style={bbStyle}>
-    <canvas id={canvasId}></canvas>
+  <canvas id={canvasId}></canvas>
 </div>

--- a/src/components/Chart.svelte
+++ b/src/components/Chart.svelte
@@ -1,76 +1,77 @@
 <script>
 
-// Main component combining all grids, scales, etc.
-// Also, main event router, root of 'update' events
+  // Main component combining all grids, scales, etc.
+  // Also, main event router, root of 'update' events
 
-import { onMount, onDestroy } from 'svelte'
-import Cursor from '../core/cursor.js'
-import DataHub from '../core/dataHub.js'
-import MetaHub from '../core/metaHub.js'
-import Scan from '../core/dataScanner.js'
-import Events from '../core/events.js'
-import Const from '../stuff/constants.js'
-import Utils from '../stuff/utils.js'
-import Layout from '../core/layout.js'
-import Context from '../stuff/context.js'
-import Pane from './Pane.svelte'
-import Botbar from './Botbar.svelte'
-import NoDataStub from './NoDataStub.svelte'
+  import { onMount, onDestroy } from 'svelte'
+  import Cursor from '../core/cursor.js'
+  import DataHub from '../core/dataHub.js'
+  import MetaHub from '../core/metaHub.js'
+  import Scan from '../core/dataScanner.js'
+  import Events from '../core/events.js'
+  import Const from '../stuff/constants.js'
+  import Utils from '../stuff/utils.js'
+  import Layout from '../core/layout.js'
+  import Context from '../stuff/context.js'
+  import Pane from './Pane.svelte'
+  import Botbar from './Botbar.svelte'
+  import NoDataStub from './NoDataStub.svelte'
 
-export let props = {}
+  export let props = {}
 
-// Getters
-export function getLayout() { return layout }
-export function getRange() { return range }
-export function getCursor() { return cursor }
+  // Getters
+  export function getLayout() { return layout }
+  export function getRange() { return range }
+  export function getCursor() { return cursor }
 
-// Setters
-export function setRange(val) {
-    let emit = !(val.preventDefault ?? true)
-    delete val.preventDefault
-    Object.assign(range, val) // keeping the same ref
-    onRangeChanged(range, emit)
-}
+  // Setters
+  export function setRange(val) {
+      let emit = !(val.preventDefault ?? true)
+      delete val.preventDefault
+      Object.assign(range, val) // keeping the same ref
+      onRangeChanged(range, emit)
+  }
 
-export function setCursor(val) {
-    let emit = !(val.preventDefault ?? true)
-    delete val.preventDefault
-    Object.assign(cursor, val)
-    onCursorChanged(cursor, emit)
-}
+  export function setCursor(val) {
+      let emit = !(val.preventDefault ?? true)
+      delete val.preventDefault
+      Object.assign(cursor, val)
+      onCursorChanged(cursor, emit)
+  }
 
-// Singleton instances
-let hub = DataHub.instance(props.id)
-let meta = MetaHub.instance(props.id)
-let events = Events.instance(props.id)
-let scan = Scan.instance(props.id)
+  // Singleton instances
+  let hub = DataHub.instance(props.id)
+  let meta = MetaHub.instance(props.id)
+  let events = Events.instance(props.id)
+  let scan = Scan.instance(props.id)
 
-scan.init(props)
+  scan.init(props)
 
-let interval = scan.detectInterval()
-let timeFrame = scan.getTimeframe()
-let range = scan.defaultRange()
-let cursor = new Cursor(meta)
-let storage = {} // Storage for helper variables
-let ctx = new Context(props) // For measuring text
-let chartRR = 0
-let layout = null
+  let interval = scan.detectInterval()
+  let timeFrame = scan.getTimeframe()
+  let range = scan.defaultRange()
+  let cursor = new Cursor(meta)
+  let storage = {} // Storage for helper variables
+  let ctx = new Context(props) // For measuring text
+  let chartRR = 0
+  let layout = null
+  let grids = []
 
-scan.calcIndexOffsets()
+  scan.calcIndexOffsets()
 
-$:chartProps = Object.assign(
-    {interval, timeFrame, range, ctx, cursor},
-    props
-)
+  $:chartProps = Object.assign(
+      {interval, timeFrame, range, ctx, cursor},
+      props
+  )
 
 // EVENT INTEFACE
-events.on('chart:cursor-changed', onCursorChanged)
-events.on('chart:cursor-locked', onCursorLocked)
-events.on('chart:range-changed', onRangeChanged)
-events.on('chart:update-layout', update)
-events.on('chart:full-update', fullUpdate)
+  events.on('chart:cursor-changed', onCursorChanged)
+  events.on('chart:cursor-locked', onCursorLocked)
+  events.on('chart:range-changed', onRangeChanged)
+  events.on('chart:update-layout', update)
+  events.on('chart:full-update', fullUpdate)
 
-onMount(() => {
+  onMount(() => {
 
     hub.calcSubset(range)
     hub.detectMain()
@@ -191,9 +192,10 @@ function rangeUpdate($range) {
             layout={layout.grids[i]}
             props={chartProps}
             main={pane === hub.chart}
+            bind:grid={grids[i]}
         />
         {/each}
-        <Botbar props={chartProps} {layout}/>
+      <Botbar props={chartProps} {layout} {grids} />
     {:else}
         <NoDataStub {props}/>
     {/if}

--- a/src/components/Pane.svelte
+++ b/src/components/Pane.svelte
@@ -1,29 +1,29 @@
 <script>
 
-// Pane component: combines grid, sidebars & legend
+  // Pane component: combines grid, sidebars & legend
 
-import { onMount, onDestroy } from 'svelte'
-import Grid from './Grid.svelte'
-import Sidebar from './Sidebar.svelte'
-import SidebarStub from './SidebarStub.svelte'
-import Legend from './Legend.svelte'
-import Events from '../core/events.js'
-import Utils from '../stuff/utils.js'
+  import { onMount, onDestroy } from 'svelte'
+  import Grid from './Grid.svelte'
+  import Sidebar from './Sidebar.svelte'
+  import SidebarStub from './SidebarStub.svelte'
+  import Legend from './Legend.svelte'
+  import Events from '../core/events.js'
+  import Utils from '../stuff/utils.js'
 
-export let id // Pane id
-export let props // General props
-export let main // Is this the main Pane
-export let layout // Pane/grid layout
+  export let id // Pane id
+  export let props // General props
+  export let main // Is this the main Pane
+  export let layout // Pane/grid layout
 
-let events = Events.instance(props.id)
-let lsb  // left sidebar ref
-let rsb  // right sidebar ref
-let grid // grid ref
+  let events = Events.instance(props.id)
+  let lsb  // left sidebar ref
+  let rsb  // right sidebar ref
+  export let grid // grid ref
 
-$:leftSb = Utils.getScalesBySide(0, layout)
-$:rightSb = Utils.getScalesBySide(1, layout)
+  $:leftSb = Utils.getScalesBySide(0, layout)
+  $:rightSb = Utils.getScalesBySide(1, layout)
 
-$:style = `
+  $:style = `
     width: ${props.width}px;
     height: ${(layout || {}).height}px;
     /* didn't work, coz canvas draws through the border
@@ -32,20 +32,20 @@ $:style = `
     box-sizing: border-box;*/
 `
 
-// EVENT INTEFACE
-events.on(`pane-${id}:update-pane`, update)
+  // EVENT INTEFACE
+  events.on(`pane-${id}:update-pane`, update)
 
-onMount(() => {
+  onMount(() => {
     // console.log(`Pane ${id} mounted`)
-})
+  })
 
-onDestroy(() => {
+  onDestroy(() => {
     events.off(`pane-${id}`)
-})
+  })
 
-// Send updates to all child components
-// Update layout ref to get faster updates
-function update($layout) {
+  // Send updates to all child components
+  // Update layout ref to get faster updates
+  function update($layout) {
     if (!$layout.grids) return
     layout = $layout.grids[id]
     events.emitSpec(`grid-${id}`, 'update-grid', layout)
@@ -55,28 +55,28 @@ function update($layout) {
     if (rsb) rsb.setLayers(layers)
     events.emitSpec(`sb-${id}-left`, 'update-sb', layout)
     events.emitSpec(`sb-${id}-right`, 'update-sb', layout)
-}
+  }
 
 </script>
 <style>
 </style>
 {#if layout}
-<div class="nvjs-pane" {style}>
+  <div class="nvjs-pane" {style}>
     <Grid {id} {props} {layout} {main} bind:this={grid}/>
     <Legend {id} {props} {layout} {main}/>
     {#if leftSb.length}
-        <Sidebar {id} {props} {layout} bind:this={lsb}
-            side='left' scales={leftSb}/>
+      <Sidebar {id} {props} {layout} bind:this={lsb}
+        side='left' scales={leftSb}/>
     {:else}
-        <SidebarStub {id} {props} {layout}
+      <SidebarStub {id} {props} {layout}
             side='left'/>
     {/if}
     {#if rightSb.length}
-        <Sidebar {id} {props} {layout}  bind:this={rsb}
-            side='right' scales={rightSb}/>
+      <Sidebar {id} {props} {layout}  bind:this={rsb}
+        side='right' scales={rightSb}/>
     {:else}
-        <SidebarStub {id} {props} {layout}
+      <SidebarStub {id} {props} {layout}
             side='right'/>
     {/if}
-</div>
+  </div>
 {/if}

--- a/src/components/Sidebar.svelte
+++ b/src/components/Sidebar.svelte
@@ -1,177 +1,177 @@
 <script>
-// The Side Bar. Information flow:
-// Input: props, layout, mouse/touch events
-// Output: canvas, ytransform events
+  // The Side Bar. Information flow:
+  // Input: props, layout, mouse/touch events
+  // Output: canvas, ytransform events
 
-// TODO: right-click menu
-// - Reset this scale
-// - Reset All Scales
-// - Move ...
+  // TODO: right-click menu
+  // - Reset this scale
+  // - Reset All Scales
+  // - Move ...
 
-// TODO: add support of overlays with
-// drawSidebar() function
+  // TODO: add support of overlays with
+  // drawSidebar() function
 
-// TODO: hiver hint component (e.g. for sidebar errors)
+  // TODO: hiver hint component (e.g. for sidebar errors)
 
-import { onMount, onDestroy } from 'svelte'
-import { fade } from 'svelte/transition'
-import ScaleSelector from './ScaleSelector.svelte'
-import Events from '../core/events.js'
-import Utils from '../stuff/utils.js'
-import Const from '../stuff/constants.js'
-import math from '../stuff/math.js'
-import dpr from '../stuff/dprCanvas.js'
-import sb from '../core/primitives/sidebar.js'
-import MetaHub from '../core/metaHub.js'
+  import { onMount, onDestroy } from 'svelte'
+  import { fade } from 'svelte/transition'
+  import ScaleSelector from './ScaleSelector.svelte'
+  import Events from '../core/events.js'
+  import Utils from '../stuff/utils.js'
+  import Const from '../stuff/constants.js'
+  import math from '../stuff/math.js'
+  import dpr from '../stuff/dprCanvas.js'
+  import sb from '../core/primitives/sidebar.js'
+  import MetaHub from '../core/metaHub.js'
 
-export let id // Sidebar id (=pane/grid id)
-export let props = {} // General props
-export let layout = {} // Grid layout
-export let side // Left/right side
-export let scales = [] // List of scales
+  export let id // Sidebar id (=pane/grid id)
+  export let props = {} // General props
+  export let layout = {} // Grid layout
+  export let side // Left/right side
+  export let scales = [] // List of scales
 
-let layers = []
-export function setLayers($layers) {
+  let layers = []
+  export function setLayers($layers) {
     layers = $layers
-}
+  }
 
-let meta = MetaHub.instance(props.id)
-let events = Events.instance(props.id)
+  let meta = MetaHub.instance(props.id)
+  let events = Events.instance(props.id)
 
-let S = side === 'right' ? 1 : 0
+  let S = side === 'right' ? 1 : 0
 
-let sbUpdId = `sb-${id}-${side}`
-let sbId = `${props.id}-sb-${id}-${side}`
-let canvasId = `${props.id}-sb-canvas-${id}-${side}`
-let showSwitch = false
-let showPanel = true
+  let sbUpdId = `sb-${id}-${side}`
+  let sbId = `${props.id}-sb-${id}-${side}`
+  let canvasId = `${props.id}-sb-canvas-${id}-${side}`
+  let showSwitch = false
+  let showPanel = true
 
-// EVENT INTERFACE
-events.on(`${sbUpdId}:update-sb`, update)
-events.on(`${sbUpdId}:show-sb-panel`, f => showPanel = f)
+  // EVENT INTERFACE
+  events.on(`${sbUpdId}:update-sb`, update)
+  events.on(`${sbUpdId}:show-sb-panel`, f => showPanel = f)
 
-$:sbStyle = `
+  $:sbStyle = `
     left: ${S * (layout.width + layout.sbMax[0])}px;
     top: ${layout.offset || 0}px;
     position: absolute;
     background: ${props.colors.back};
     height: ${layout.height}px;
-`
-$:scale = getCurrentScale(layout)
+  `
+  $:scale = getCurrentScale(layout)
 
-let canvas // Canvas ref
-let ctx // Canvas context
-let mc // Mouse controller
-let zoom = 1
-let yRange
-let drug
-let updId 
+  let canvas // Canvas ref
+  let ctx // Canvas context
+  let mc // Mouse controller
+  let zoom = 1
+  let yRange
+  let drug
+  let updId
 
-$:width = layout.width
-$:height = layout.height
-$:resizeWatch(width, height)
+  $:width = layout.width
+  $:height = layout.height
+  $:resizeWatch(width, height)
 
-onMount(async () => { await setup() })
-onDestroy(() => {
+  onMount(async () => { await setup() })
+  onDestroy(() => {
     events.off(`${sbUpdId}`)
     if (mc) mc.destroy()
     clearInterval(updId)
-})
+  })
 
-async function setup() {
+  async function setup() {
     [canvas, ctx] = dpr.setup(
         canvasId, layout.sbMax[S], layout.height)
 
     update()
     if (scale) await listeners()
 
-    // Start updates to show fresh candle time 
+    // Start updates to show fresh candle time
     if (props.config.CANDLE_TIME && props.timeFrame >= Const.MINUTE) {
-        let dt = Const.SECOND / 5 
-        updId = setInterval(update, dt)
+      let dt = Const.SECOND / 5
+      updId = setInterval(update, dt)
     }
-}
+  }
 
-// TODO: add mouse wheel/touchpad zoom
-async function listeners() {
+  // TODO: add mouse wheel/touchpad zoom
+  async function listeners() {
     const Hammer = await import('hammerjs');
     mc = new Hammer.Manager(canvas)
-        mc.add(new Hammer.Pan({
-            direction: Hammer.DIRECTION_VERTICAL,
-            threshold: 0
-        }))
+    mc.add(new Hammer.Pan({
+        direction: Hammer.DIRECTION_VERTICAL,
+        threshold: 0
+      }))
 
-        mc.add( new Hammer.Tap({
-            event: 'doubletap',
-            taps: 2,
-            posThreshold: 50
-        }))
+    mc.add( new Hammer.Tap({
+        event: 'doubletap',
+        taps: 2,
+        posThreshold: 50
+      }))
 
-        mc.on('panstart', event => {
-            if (!scale) return
-            let yTransform = getYtransform()
-            if (yTransform) {
-                zoom = yTransform.zoom
-            } else {
-                zoom = 1.0
-            }
-            yRange = [
+    mc.on('panstart', event => {
+      if (!scale) return
+      let yTransform = getYtransform()
+      if (yTransform) {
+        zoom = yTransform.zoom
+      } else {
+        zoom = 1.0
+      }
+      yRange = [
                 scale.$hi,
                 scale.$lo
             ]
-            drug = {
-                y: event.center.y,
-                z: zoom,
-                mid: math.log_mid(yRange, layout.height),
-                A: scale.A,
-                B: scale.B
-            }
+      drug = {
+        y: event.center.y,
+        z: zoom,
+        mid: math.log_mid(yRange, layout.height),
+        A: scale.A,
+        B: scale.B
+      }
+    })
+
+    mc.on('panmove', event => {
+      if (drug) {
+        zoom = calcZoom(event)
+        events.emit('sidebar-transform', {
+          gridId: id,
+          scaleId: scale.scaleSpecs.id,
+          zoom: zoom,
+          auto: false,
+          range: calcRange(),
+          drugging: true,
+          updateLayout: true
         })
+        update()
+      }
+    })
 
-        mc.on('panmove', event => {
-            if (drug) {
-                zoom = calcZoom(event)
-                events.emit('sidebar-transform', {
-                    gridId: id,
-                    scaleId: scale.scaleSpecs.id,
-                    zoom: zoom,
-                    auto: false,
-                    range: calcRange(),
-                    drugging: true,
-                    updateLayout: true
-                })
-                update()
-            }
-        })
+    mc.on('panend', () => {
+      drug = null
+      if (!scale) return
+      events.emit('sidebar-transform', {
+        gridId: id,
+        scaleId: scale.scaleSpecs.id,
+        drugging: false,
+        updateLayout: true
+      })
+    })
 
-        mc.on('panend', () => {
-            drug = null
-            if (!scale) return
-            events.emit('sidebar-transform', {
-                gridId: id,
-                scaleId: scale.scaleSpecs.id,
-                drugging: false,
-                updateLayout: true
-            })
-        })
+    mc.on('doubletap', () => {
+      events.emit('sidebar-transform', {
+        gridId: id,
+        scaleId: scale.scaleSpecs.id,
+        zoom: 1.0,
+        auto: true,
+        updateLayout: true
+      })
+      zoom = 1.0
+      update()
+    })
 
-        mc.on('doubletap', () => {
-            events.emit('sidebar-transform', {
-                gridId: id,
-                scaleId: scale.scaleSpecs.id,
-                zoom: 1.0,
-                auto: true,
-                updateLayout: true
-            })
-            zoom = 1.0
-            update()
-        })
+    // TODO: Do later for mobile version
 
-        // TODO: Do later for mobile version
+  }
 
-}
-
-function update($layout = layout) {
+  function update($layout = layout) {
 
     if (!$layout) return // If not exists
 
@@ -180,12 +180,12 @@ function update($layout = layout) {
     scale = getCurrentScale()
 
     if (!scale) {
-        return sb.error(props, layout, side, ctx)
+      return sb.error(props, layout, side, ctx)
     }
 
     // Draw only when data extracted from the srcipts
     //if (meta.ready) {
-        sb.body(props, layout, scale, side, ctx)
+    sb.body(props, layout, scale, side, ctx)
     //} else {
     //    sb.border(props, layout, side, ctx)
     //}
@@ -195,39 +195,39 @@ function update($layout = layout) {
     if (id) sb.upperBorder(props, layout, ctx)
 
     if (props.cursor.y && props.cursor.scales && showPanel) {
-        if (props.cursor.gridId === layout.id) {
-            sb.panel(props, layout, scale, side, ctx)
-        }
+      if (props.cursor.gridId === layout.id) {
+        sb.panel(props, layout, scale, side, ctx)
+      }
     }
-}
+  }
 
-// Draw stuff from overlay scripts
-function ovDrawCalls() {
+  // Draw stuff from overlay scripts
+  function ovDrawCalls() {
     for (var l of layers) {
-        let ov = l.overlay
-        if (ov.drawSidebar) {
-            ov.drawSidebar(ctx, side, scale)
-        }
+      let ov = l.overlay
+      if (ov.drawSidebar) {
+        ov.drawSidebar(ctx, side, scale)
+      }
     }
-}
+  }
 
-function resizeWatch() {
+  function resizeWatch() {
     if (!canvas) return
     dpr.resize(canvas, ctx, layout.sbMax[S], layout.height)
     update()
-}
+  }
 
-function calcZoom(event) {
+  function calcZoom(event) {
     let d = drug.y - event.center.y
     let speed = d > 0 ? 3 : 1
     let k = 1 + speed * d / layout.height
     return Utils.clamp(drug.z * k, 0.005, 100)
-}
+  }
 
-// Not the best place to calculate y-range but
-// this is the simplest solution I found up to
-// date
-function calcRange(diff1 = 1, diff2 = 1) {
+  // Not the best place to calculate y-range but
+  // this is the simplest solution I found up to
+  // date
+  function calcRange(diff1 = 1, diff2 = 1) {
 
     let z = zoom / drug.z
     let zk = (1 / z - 1) / 2
@@ -236,28 +236,28 @@ function calcRange(diff1 = 1, diff2 = 1) {
     let delta = range[0] - range[1]
 
     if (!scale.log) {
-        range[0] = range[0] + delta * zk * diff1
-        range[1] = range[1] - delta * zk * diff2
+      range[0] = range[0] + delta * zk * diff1
+      range[1] = range[1] - delta * zk * diff2
     } else {
 
-        let px_mid = layout.height / 2
-        let new_hi = px_mid - px_mid * (1 / z)
-        let new_lo = px_mid + px_mid * (1 / z)
+      let px_mid = layout.height / 2
+      let new_hi = px_mid - px_mid * (1 / z)
+      let new_lo = px_mid + px_mid * (1 / z)
 
-        // Use old mapping to get a new range
+      // Use old mapping to get a new range
         let f = y => math.exp((y - drug.B) / drug.A)
 
-        let copy = range.slice()
-        range[0] = f(new_hi)
-        range[1] = f(new_lo)
+      let copy = range.slice()
+      range[0] = f(new_hi)
+      range[1] = f(new_lo)
 
     }
 
     return range
-}
+  }
 
-// TODO: log scale work with distortions when auto is disabled
-function rezoomRange(delta, diff1, diff2) {
+  // TODO: log scale work with distortions when auto is disabled
+  function rezoomRange(delta, diff1, diff2) {
 
     let yTransform = getYtransform()
     if (!yTransform || yTransform.auto) return
@@ -271,82 +271,82 @@ function rezoomRange(delta, diff1, diff2) {
         scale.$lo
     ]
     drug = {
-        y: 0,
-        z: zoom,
-        mid: math.log_mid(yRange, layout.height),
-        A: scale.A,
+      y: 0,
+      z: zoom,
+      mid: math.log_mid(yRange, layout.height),
+      A: scale.A,
         B: scale.B
     }
     zoom = calcZoom({
-        center: {
+      center: {
             y: delta * layout.height
         }
     })
 
     events.emit('sidebar-transform', {
-        gridId: id,
-        scaleId: scale.scaleSpecs.id,
-        zoom: zoom,
-        auto: false,
-        range: calcRange(diff1, diff2),
-        drugging: true,
-        updateLayout: true // Update layout
+      gridId: id,
+      scaleId: scale.scaleSpecs.id,
+      zoom: zoom,
+      auto: false,
+      range: calcRange(diff1, diff2),
+      drugging: true,
+      updateLayout: true // Update layout
     })
     drug = null
     events.emit('sidebar-transform', {
-        gridId: id,
-        scaleId: scale.scaleSpecs.id,
-        drugging: false,
-        updateLayout: true
+      gridId: id,
+      scaleId: scale.scaleSpecs.id,
+      drugging: false,
+      updateLayout: true
     })
-}
+  }
 
-// Get current scale displayed on this side.
-// Should be in the scales list & template
-function getCurrentScale() {
+  // Get current scale displayed on this side.
+  // Should be in the scales list & template
+  function getCurrentScale() {
     let scales = layout.scales
     let template = layout.settings.scaleTemplate[S]
     let s = scales[layout.settings.scaleSideIdxs[S]]
     if (s && template.includes(s.scaleSpecs.id)) {
-        return s
+      return s
     }
     return null
-}
+  }
 
-function getYtransform() {
+  function getYtransform() {
     if (!meta.yTransforms[id]) return
     let scaleId = scale.scaleSpecs.id
     return meta.yTransforms[id][scaleId]
-}
+  }
 
-function onClick(e) {
+  function onClick(e) {
     if (!scale) return
     events.emitSpec('hub', 'set-scale-index', {
-        paneId: id,
-        index: scale.scaleSpecs.id,
-        sideIdxs: layout.settings.scaleSideIdxs
+      paneId: id,
+      index: scale.scaleSpecs.id,
+      sideIdxs: layout.settings.scaleSideIdxs
     })
-}
+  }
 
-function onMouseOver() {
+  function onMouseOver() {
     showSwitch = true
-}
+  }
 
-function onMouseLeave() {
+  function onMouseLeave() {
     showSwitch = false
-}
+  }
 
 </script>
 <style>
 .nvjs-sidebar {}
 </style>
 <div id={sbId} style={sbStyle} class="nvjs-sidebar"
-    on:click={onClick}
-    on:mouseover={onMouseOver}
+  on:click={onClick}
+  on:mouseover={onMouseOver}
     on:mouseleave={onMouseLeave}>
-    <canvas id={canvasId}></canvas>
-    {#if scales.length > 1 && showSwitch}
+  <canvas id={canvasId}></canvas>
+  {#if scales.length > 1 && showSwitch}
         <ScaleSelector {id} {props} {layout}
             {scales} {side} />
-    {/if}
+  {/if}
 </div>


### PR DESCRIPTION
Well, I was building something with the library.. and ended up needing the drawBotBar method in my navy script..

Found it was not implemented.. Got ahead and read the code.. (well installed prettier for readability, inconsistent spacing all over the files)

Implemented it.. 

What i did:
- added a grids array on Chart.svelte, binded it to the grid instance in Pane.svelte
- pass the grids array into BotBar, extract all layers `$: layers = grids.map((grid) => grid.getLayers() || []).flat()`
- call drawBotBar if present in each layer
